### PR TITLE
Run the deploy everyday before scheduled service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '57 23 * * *'
+
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
Because of limited machine resources, sometimes the memory resources are
not enough for a Java Spring application to run seamlessly 24/7. It's
often restarts with an OOM.  To avoid this, I'm using a feature to halt
the machine when not used. It works very well. But it has a downside.
When the machine is halted, then the scheduled service cannot run, and
thus I have to start the machine before it will run scheduled service.
I found the easier solution is to run the deployment with a cron.
The scheduled service runs at midnight. Thus, start the machine a
couple of minutes before.
