### PR TITLE
Call the health controller by schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '57 23 * * *'
 
 jobs:
   deploy:

--- a/.github/workflows/wake_up.yml
+++ b/.github/workflows/wake_up.yml
@@ -1,0 +1,12 @@
+name: Wake up
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+jobs:
+  make-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call health endpoint to wake up the app
+        run: |
+          response=$(curl --location 'https://rss-feed.fly.dev/actuator/health' --header 'Content-Type: application/json')
+          echo "Response from API: $response"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     implementation("com.rometools:rome:2.1.0")
     implementation("org.postgresql:postgresql")


### PR DESCRIPTION
Enable the actuator to expose the health application. Then, add a
workflow that will run by a schedule to call the health and wake up the
application.
