### PR TITLE
Add "Mark as read" button for rows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,3 @@ tasks.register<JavaExec>("playwrightInstall") {
     mainClass.set("com.microsoft.playwright.CLI")
     args = listOf("install-deps")
 }
-
-tasks.named("test").configure {
-    dependsOn("playwrightInstall")
-}

--- a/src/main/java/io/plagov/rssfeed/controller/PostController.java
+++ b/src/main/java/io/plagov/rssfeed/controller/PostController.java
@@ -30,6 +30,12 @@ public class PostController {
         return postDao.getAllUnreadPosts();
     }
 
+    /**
+     * @deprecated
+     * This controller is replaced by a View Controller.
+     * <p>See {@link io.plagov.rssfeed.view.PostsView#markPostAsRead}</p>
+     */
+    @Deprecated
     @PatchMapping("/mark-as-read/{id}")
     public void markPostAsRead(@PathVariable("id") int postId) {
         postDao.markPostAsRead(postId);

--- a/src/main/java/io/plagov/rssfeed/view/PostsView.java
+++ b/src/main/java/io/plagov/rssfeed/view/PostsView.java
@@ -4,6 +4,8 @@ import io.plagov.rssfeed.dao.PostDao;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class PostsView {
@@ -19,5 +21,11 @@ public class PostsView {
         var posts = postDao.getAllUnreadPosts();
         model.addAttribute("posts", posts);
         return "index";
+    }
+
+    @PostMapping("/mark-as-read")
+    public String markPostAsRead(@RequestParam String id) {
+        postDao.markPostAsRead(Integer.parseInt(id));
+        return "redirect:/";
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -16,16 +16,23 @@
         <th>ID</th>
         <th>Title</th>
         <th>Date added</th>
+        <th>Mark as read</th>
     </tr>
     </thead>
     <tbody>
     <tr th:if="${posts.isEmpty()}">
         <td colspan="2">No posts available</td>
     </tr>
-    <tr th:each="post : ${posts}">
+    <tr th:each="post : ${posts}" th:attr="data-testid=${'post-' + post.id}">
         <td><span th:text="${post.id}">ID</span></td>
         <td><a th:text="${post.name}" th:href="@{${post.url}}" target="_blank">Title</a></td>
         <td><span th:text="${#temporals.format(post.dateAdded, 'yyyy-MM-dd')}">Date added</span></td>
+        <td>
+            <form method="post" th:action="@{/mark-as-read}">
+                <input type="hidden" th:value="${post.id}" name="id">
+                <button type="submit" class="btn btn-primary">Mark as read</button>
+            </form>
+        </td>
     </tr>
     </tbody>
 </table>

--- a/src/test/java/io/plagov/rssfeed/E2eBaseTest.java
+++ b/src/test/java/io/plagov/rssfeed/E2eBaseTest.java
@@ -14,7 +14,7 @@ public abstract class E2eBaseTest {
     @BeforeEach
     void setUpPlaywright() {
         playwright = Playwright.create();
-        browser = playwright.webkit().launch();
+        browser = playwright.chromium().launch();
         page = browser.newPage();
     }
 }

--- a/src/test/java/io/plagov/rssfeed/view/PostViewTest.java
+++ b/src/test/java/io/plagov/rssfeed/view/PostViewTest.java
@@ -34,7 +34,7 @@ class PostViewTest extends E2eBaseTest {
     void canViewCorrectNumberOfColumns() {
         page.navigate("http://localhost:" + port);
         var columnHeadings = page.locator("table thead tr th").allTextContents();
-        Assertions.assertThat(columnHeadings).containsExactly("ID", "Title", "Date added");
+        Assertions.assertThat(columnHeadings).containsExactly("ID", "Title", "Date added", "Mark as read");
     }
 
     @Test
@@ -43,5 +43,14 @@ class PostViewTest extends E2eBaseTest {
         page.navigate("http://localhost:" + port);
         var postTitleCell = page.locator("tbody > tr:nth-child(1) > td:nth-child(2) > a");
         PlaywrightAssertions.assertThat(postTitleCell).hasAttribute("href", "https://post1.com");
+    }
+
+    @Test
+    @Sql("/sql/posts/add_posts.sql")
+    void userCanMarkPostAsRead() {
+        page.navigate("http://localhost:" + port);
+        page.locator("tr[data-testid='post-2'] button").click();
+        var remainingRow = page.locator("tr[data-testid='post-1'] td:nth-child(2)");
+        PlaywrightAssertions.assertThat(remainingRow).hasText("Post 1");
     }
 }


### PR DESCRIPTION
Now, it is possible to mark the post as read right on the page. Added
a new view controller for that purpose.
Also, changed the browser engine from webkit to chromium. The webKit is
used mostly by Safari, and this is not my target browser engine. Plus,
it is not supported on Fedora. For the same reason, I removed the
dependence of the `test` task on the `playwrightInstall` task.

The `/mark-as-read` endpoint in the PostController is deprecated to be
able to find it easier later on to remove it.
