### PR TITLE
Remove deprecated REST controller

### DIFF
--- a/src/main/java/io/plagov/rssfeed/controller/PostController.java
+++ b/src/main/java/io/plagov/rssfeed/controller/PostController.java
@@ -4,8 +4,6 @@ import io.plagov.rssfeed.dao.PostDao;
 import io.plagov.rssfeed.domain.response.PostResponse;
 import io.plagov.rssfeed.service.PostService;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,17 +26,6 @@ public class PostController {
     @GetMapping("/unread")
     public List<PostResponse> getAllUnreadPosts() {
         return postDao.getAllUnreadPosts();
-    }
-
-    /**
-     * @deprecated
-     * This controller is replaced by a View Controller.
-     * <p>See {@link io.plagov.rssfeed.view.PostsView#markPostAsRead}</p>
-     */
-    @Deprecated
-    @PatchMapping("/mark-as-read/{id}")
-    public void markPostAsRead(@PathVariable("id") int postId) {
-        postDao.markPostAsRead(postId);
     }
 
     @PostMapping("/fetch-latest")

--- a/src/test/java/io/plagov/rssfeed/controller/PostTest.java
+++ b/src/test/java/io/plagov/rssfeed/controller/PostTest.java
@@ -62,13 +62,4 @@ class PostTest {
                 false,
                 LocalDateTime.parse("2023-01-01T12:00")));
     }
-
-    @Test
-    @Sql("/sql/posts/add_posts.sql")
-    void shouldMarkPostAsRead() {
-        postController.markPostAsRead(2);
-
-        var unreadPosts = postController.getAllUnreadPosts();
-        assertThat(unreadPosts).hasSize(1);
-    }
 }


### PR DESCRIPTION
This operation has been transferred to the view model of the app. The
endpoint is not used directly anymore.
