### PR TITLE
Update GH Actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,9 @@ jobs:
     name: Deploy app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 21

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 21
@@ -27,9 +27,3 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3.7.2
-        if: always()
-        with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
Remove test report. The less infra dependencies, the easier. Less to
track.
