### PR TITLE
Define Testcontainers image in properties file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,12 @@
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "automerge": true
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^testcontainers-images.properties$"],
+      "matchStrings": ["database=?(?<depName>.*?):(?<currentValue>.*?)\n"],
+      "datasourceTemplate": "docker"
+    }
   ]
 }

--- a/src/test/java/io/plagov/rssfeed/configuration/ContainersConfig.java
+++ b/src/test/java/io/plagov/rssfeed/configuration/ContainersConfig.java
@@ -1,17 +1,23 @@
 package io.plagov.rssfeed.configuration;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
+@PropertySource("classpath:testcontainers-images.properties")
 public class ContainersConfig {
+
+    @Value("${database}")
+    private String databaseImage;
 
     @Bean
     @ServiceConnection
     public PostgreSQLContainer<?> postgreSQLContainer() {
-        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:15.6"));
+        return new PostgreSQLContainer<>(DockerImageName.parse(databaseImage));
     }
 }

--- a/src/test/resources/testcontainers-images.properties
+++ b/src/test/resources/testcontainers-images.properties
@@ -1,0 +1,1 @@
+database=postgres:15.6


### PR DESCRIPTION
When a docker tag used for Testcontainers is defined in an external properties file, then it is possible to write a regex manager for the Renovate so that it will scan this file, extract an image name and tag and will scan it against the docker. This way, the image will eb always up to date.